### PR TITLE
Updated GetParamsByName's path

### DIFF
--- a/Prokast.Server/Controllers/ParamsController.cs
+++ b/Prokast.Server/Controllers/ParamsController.cs
@@ -66,7 +66,7 @@ namespace Prokast.Server.Controllers
         #endregion
 
         #region getParamsByName
-        [HttpGet("/name/{name}")]
+        [HttpGet("name/{name}")]
         public ActionResult<Response> GetParamsByName([FromQuery] int clientID, [FromRoute] string name)
         {
             try


### PR DESCRIPTION
Zmieniłem ścieżkę dla jednego geta, żeby poprawnie robiło api/params/name/{name} zamiast tylko name/{name}